### PR TITLE
Clean up M&DS data store interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,19 +178,23 @@ Usage:
 
 The output directory is assumed to already exist.
 
-## Connectivity data
+## RRAP M&DS data store interface
 
-Download connectivity data from M&DS datastore
+Download data from M&DS datastore
 
 ```console
-(rrap-dg) $ rrapdg connectivity download [output directory] [dataset id]
+(rrap-dg) $ rrapdg data_store download [dataset id] [output directory]
 ```
 
 For example, to download and save the dataset with id "102.100.100/602432" in the current directory:
 
 ```console
-(rrap-dg) $ rrapdg connectivity download . 102.100.100/602432
+(rrap-dg) $ rrapdg data_store download 102.100.100/602432 .
 ```
+
+Semantically, the command is to download from a *source* to a *destination*.
+
+**TODO: Uploading/submitting datasets.**
 
 ## Wave data
 

--- a/rrap_dg/data_store/__init__.py
+++ b/rrap_dg/data_store/__init__.py
@@ -1,0 +1,1 @@
+from .data_store import app

--- a/rrap_dg/data_store/data_store.py
+++ b/rrap_dg/data_store/data_store.py
@@ -1,0 +1,50 @@
+from typing import Callable
+from os.path import join as pj
+from glob import glob
+
+import numpy as np
+import pandas as pd
+
+import datapackage as dpkg
+import boto3
+
+# This is a helper function for managing authentication with Provena
+import mdsisclienttools.auth.TokenManager as ProvenaAuth
+import mdsisclienttools.datastore.ReadWriteHelper as ProvenaRW
+
+import typer
+
+
+# Provena Config
+# Replace the domain with the domain of your Provena instance
+PROVENA_DOMAIN = "mds.gbrrestoration.org"
+
+app = typer.Typer()
+
+@app.command(help="Download data from RRAP M&DS Data Store by handle id.")
+def download(
+    handle_id: str,
+    dest: str
+) -> None:
+    """Download data from the RRAP M&DS data store using a handle id.
+
+       Parameters
+       ----------
+       dest: str, output location of downloaded connectivity matrices
+       handle_id: str, dataset id of the connectivity matrices
+    """
+
+    data_store_endpoint = "https://data-api.{}".format(PROVENA_DOMAIN)
+    # Edit this to point to the Keycloak instance for your Provena instance
+    kc_endpoint = "https://auth.mds.gbrrestoration.org/auth/realms/rrap"
+
+    stage = "PROD"
+    provena_auth = ProvenaAuth.DeviceFlowManager(
+        stage=stage,
+        keycloak_endpoint=kc_endpoint,
+        auth_flow=ProvenaAuth.AuthFlow.DEVICE,
+    )
+
+    # expose the get auth function which is used for provena methods
+    get_auth = provena_auth.get_auth
+    ProvenaRW.download(data_store_api_endpoint=data_store_endpoint,handle=handle_id, auth=get_auth(), download_path=dest)

--- a/rrap_dg/main.py
+++ b/rrap_dg/main.py
@@ -2,7 +2,7 @@ import typer
 from rrap_dg import dhw
 from rrap_dg import cyclones
 from rrap_dg import cluster_domain
-from rrap_dg import connectivity
+from rrap_dg import data_store
 from rrap_dg import initial_coral_cover
 
 app = typer.Typer()
@@ -10,7 +10,7 @@ app.add_typer(dhw.app, name="dhw")
 app.add_typer(cyclones.app, name="cyclones")
 app.add_typer(cluster_domain.app, name="domain")
 app.add_typer(initial_coral_cover.app, name="coral-cover")
-app.add_typer(connectivity.app, name="connectivity")
+app.add_typer(data_store.app, name="data-store")
 
 
 @app.callback()


### PR DESCRIPTION
Previously, downloading data from the M&DS data store was erroneously tied to the `connectivity` command.

This change correctly names the command.