### PR TITLE
Initial data package templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Provides a single command-line interface to generate data sets for use with [ADR
   - [Degree Heating Weeks (DHW) projections](#degree-heating-weeks-dhw-projections)
   - [Initial Coral Cover](#initial-coral-cover)
   - [Cyclone Mortality projections](#cyclone-mortality-projections)
-  - [Connectivity data](#connectivity-data)
+  - [RRAP M\&DS data store interface](#rrap-mds-data-store-interface)
   - [Wave data](#wave-data)
   - [Domain clusters](#domain-clusters)
   - [License](#license)
@@ -196,13 +196,13 @@ The output directory is assumed to already exist.
 Download data from M&DS datastore
 
 ```console
-(rrap-dg) $ rrapdg data_store download [dataset id] [output directory]
+(rrap-dg) $ rrapdg data-store download [dataset id] [output directory]
 ```
 
 For example, to download and save the dataset with id "102.100.100/602432" in the current directory:
 
 ```console
-(rrap-dg) $ rrapdg data_store download 102.100.100/602432 .
+(rrap-dg) $ rrapdg data-store download 102.100.100/602432 .
 ```
 
 Semantically, the command is to download from a *source* to a *destination*.

--- a/README.md
+++ b/README.md
@@ -118,13 +118,20 @@ https://hdl.handle.net/102.100.100/481718
 
 ## Domain Template
 
-**TODO**
-
 Create an empty ADRIA Domain to be filled with data.
 
 ```console
 (rrap-dg) $ rrapdg template generate [directory]
 ```
+
+**TODO:** Package an ADRIA Domain with data from the M&DS data store.
+
+```console
+(rrap-dg) $ rrapdg template package [directory] [spec]
+```
+
+Where spec points to a json file defining handle IDs for each dataset to be downloaded
+from the M&DS data store.
 
 ## Degree Heating Weeks (DHW) projections
 

--- a/rrap_dg/dpkg_template/__init__.py
+++ b/rrap_dg/dpkg_template/__init__.py
@@ -1,0 +1,1 @@
+from .dpkg_template import app

--- a/rrap_dg/dpkg_template/dpkg_template.py
+++ b/rrap_dg/dpkg_template/dpkg_template.py
@@ -5,10 +5,10 @@ from datetime import datetime
 import typer
 
 
-README_BASE = f"""
+README_BASE = """
 # ADRIA data package
 
-Created: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+Created: {created}
 
 
 ## Connectivity
@@ -39,7 +39,7 @@ def generate(template_path: str):
     open(pj(template_path, "datapackage.json"), "a").close()
 
     with open(pj(template_path, "README.md"), "a") as fp:
-        fp.write(README_BASE)
+        fp.write(README_BASE.format(created=datetime.now().strftime("%Y-%m-%d %H:%M:%S")))
 
 @app.command(help="Create ADRIA Domain data package pre-filling with data from data store")
 def package(template_path: str, spec: str):

--- a/rrap_dg/dpkg_template/dpkg_template.py
+++ b/rrap_dg/dpkg_template/dpkg_template.py
@@ -1,0 +1,49 @@
+import os
+from os.path import join as pj
+from datetime import datetime
+
+import typer
+
+
+README_BASE = f"""
+# ADRIA data package
+
+Created: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+
+
+## Connectivity
+
+
+## Cyclones
+
+
+## DHWs
+
+
+## Spatial
+
+
+## Waves
+"""
+
+
+app = typer.Typer()
+
+@app.command(help="Create empty ADRIA Domain data package")
+def generate(template_path: str):
+    os.makedirs(pj(template_path, "connectivity"))
+    os.makedirs(pj(template_path, "cyclones"))
+    os.makedirs(pj(template_path, "DHWs"))
+    os.makedirs(pj(template_path, "spatial"))
+    os.makedirs(pj(template_path, "waves"))
+    open(pj(template_path, "datapackage.json"), "a").close()
+
+    with open(pj(template_path, "README.md"), "a") as fp:
+        fp.write(README_BASE)
+
+@app.command(help="Create ADRIA Domain data package pre-filling with data from data store")
+def package(template_path: str, spec: str):
+    print("Not yet implemented")
+
+    # generate(template_path)
+    # TODO: download datasets defined in a spec file to appropriate sub-directories

--- a/rrap_dg/main.py
+++ b/rrap_dg/main.py
@@ -4,6 +4,7 @@ from rrap_dg import cyclones
 from rrap_dg import cluster_domain
 from rrap_dg import data_store
 from rrap_dg import initial_coral_cover
+from rrap_dg import dpkg_template
 
 app = typer.Typer()
 app.add_typer(dhw.app, name="dhw")
@@ -11,6 +12,7 @@ app.add_typer(cyclones.app, name="cyclones")
 app.add_typer(cluster_domain.app, name="domain")
 app.add_typer(initial_coral_cover.app, name="coral-cover")
 app.add_typer(data_store.app, name="data-store")
+app.add_typer(dpkg_template.app, name="template")
 
 
 @app.callback()


### PR DESCRIPTION
Support creation of an empty ADRIA Domain.

TODO: Package a Domain together using data from the M&DS data store, specified by their handle ids.