### PR TITLE
Support creating multiple initial coral covers with user-specifiable bin sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,67 @@ For example, to downscale RME data for the Moore cluster defined by a geopackage
 (rrap-dg) $ rrapdg coral-cover downscale-icc C:/example/rme_dataset ./Moore.gpkg ./coral_cover.nc
 ```
 
+A set of initial cover files can be created using a TOML file:
+
+```console
+(rrap-dg) $ rrapdg coral-cover downscale-icc [rrap-dg datapackage path] [target geopackage] [output directory] [TOML file]
+```
+
+The output path is assumed to exist.
+
+```console
+(rrap-dg) $ rrapdg coral-cover bin-edge-icc C:/example/rrapdg ./Moore.gpkg ./icc_files ./bin_edges.toml
+```
+
+This will create a set of netCDFs in the `icc_files` directory using the bin edges defined
+in the TOML file.
+
+The format of the TOML file is:
+
+```TOML
+name_of_file = [
+    [values, for, each, size class],
+	[rows, are, functional, groups],
+	[cols, are size, classes]
+]
+```
+
+Note that ReefMod represents arborescent Acropora, whereas CoralBlocks does not.
+Hence the first line is set to 0.0.
+
+A full example:
+
+```TOML
+bin_edge_1 = [
+	[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+	[5.0, 7.5, 10.0, 20.0, 40.0, 100.0, 150.0],
+	[5.0, 7.5, 10.0, 20.0, 35.0, 50.0, 100.0],
+	[5.0, 7.5, 10.0, 15.0, 20.0, 40.0, 50.0],
+	[5.0, 7.5, 10.0, 20.0, 40.0, 50.0, 100.0],
+	[5.0, 7.5, 10.0, 20.0, 40.0, 50.0, 100.0]
+]
+
+bin_edge_2 = [
+	[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+	[4.0, 7.5, 10.0, 20.0, 40.0, 100.0, 150.0],
+	[4.0, 7.5, 10.0, 20.0, 35.0, 50.0, 100.0],
+	[4.0, 7.5, 10.0, 15.0, 20.0, 40.0, 50.0],
+	[4.0, 7.5, 10.0, 20.0, 40.0, 50.0, 100.0],
+	[4.0, 7.5, 10.0, 20.0, 40.0, 50.0, 100.0]
+]
+
+bin_edge_3 = [
+	[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+	[5.0, 7.5, 10.0, 20.0, 40.0, 100.0, 100.0],
+	[5.0, 7.5, 10.0, 20.0, 35.0, 50.0, 120.0],
+	[5.0, 7.5, 10.0, 15.0, 20.0, 40.0, 60.0],
+	[5.0, 7.5, 10.0, 20.0, 40.0, 50.0, 110.0],
+	[5.0, 7.5, 10.0, 20.0, 40.0, 50.0, 120.0]
+]
+```
+
+Using the above will create files named `bin_edge_1`, `bin_edge_2`, ..., etc.
+
 ## Cyclone Mortality projections
 
 Generate Cyclone Mortality projections using data from

--- a/rrap_dg/initial_coral_cover/initial_coral_cover.py
+++ b/rrap_dg/initial_coral_cover/initial_coral_cover.py
@@ -14,3 +14,13 @@ def downscale_icc(
     output_path: str,
 ) -> None:
     jl.downscale_icc(rrapdg_dpkg_path, target_cluster, output_path)
+
+
+@app.command(help="Create initial coral cover netCDFs with custom bin edges defined in a TOML file.")
+def bin_edge_icc(
+    rrapdg_dpkg_path: str,
+    target_cluster: str,
+    output_path: str,
+    bin_edge_file: str
+) -> None:
+    jl.downscale_icc(rrapdg_dpkg_path, target_cluster, output_path, bin_edge_file)

--- a/rrap_dg/juliapkg.json
+++ b/rrap_dg/juliapkg.json
@@ -53,6 +53,10 @@
             "uuid": "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91",
             "version": "0.34.2"
         },
+        "TOML": {
+            "uuid": "fa267f1f-6049-4f14-aa54-33bafae1ed76",
+            "version": "1.0.3"
+        },
         "YAXArrays": {
             "uuid": "c21b50f5-aa40-41ea-b809-c0f5e47bfa5c",
             "version": "0.5.2"


### PR DESCRIPTION
**To be merged after #12**

See expanded readme for usage.

A few notes for creating multiple initial covers:

The current CoralBlox implementation has an extra bin (the terminal class).
To accommodate, I've elected to ignore the "initial" size class by not defining it.

Similarly, because ReefMod has an extra functional group I've specified the bin edges for these to be all zero.
I'm unsure what the implications of this are, so it should be checked for sanity.