### PR TITLE
configure juliapkg to use Julia 1.11

### DIFF
--- a/rrap_dg/juliapkg.json
+++ b/rrap_dg/juliapkg.json
@@ -1,5 +1,5 @@
 {
-    "julia": "1.10.4",
+    "julia": "~1.11",
     "packages": {
         "ArchGDAL": {
             "uuid": "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3",


### PR DESCRIPTION
I have both Julia 1.11 and 1.12 installed by juliaup.

`uv run rrapdg` runs with Julia 1.12, which fails to complie `DimensionalData`

```
(rrap-dg) awhite@AIMS-GKBNR74:~/code/rrap-dg$ uv run rrapdg
[juliapkg] Found dependencies: /home/awhite/code/rrap-dg/.venv/lib/python3.11/site-packages/juliacall/juliapkg.json
[juliapkg] Found dependencies: /home/awhite/code/rrap-dg/rrap_dg/juliapkg.json
[juliapkg] Found dependencies: /home/awhite/code/rrap-dg/.venv/lib/python3.11/site-packages/juliapkg/juliapkg.json
[juliapkg] Locating Julia ^1.11
[juliapkg] Using Julia 1.12.4 at /home/awhite/.julia/juliaup/julia-1.12.4+0.x64.linux.gnu/bin/julia
[juliapkg] Using Julia project at /home/awhite/code/rrap-dg/.venv/julia_env
```

with this change, it resolves Julia 1.11

```
(rrap-dg) awhite@AIMS-GKBNR74:~/code/rrap-dg$ uv run rrapdg
[juliapkg] Found dependencies: /home/awhite/code/rrap-dg/.venv/lib/python3.11/site-packages/juliapkg/juliapkg.json
[juliapkg] Found dependencies: /home/awhite/code/rrap-dg/.venv/lib/python3.11/site-packages/juliacall/juliapkg.json
[juliapkg] Found dependencies: /home/awhite/code/rrap-dg/rrap_dg/juliapkg.json
[juliapkg] Locating Julia ~1.11
[juliapkg] Using Julia 1.11.8 at /home/awhite/.julia/juliaup/julia-1.11.8+0.x64.linux.gnu/bin/julia
[juliapkg] Using Julia project at /home/awhite/code/rrap-dg/.venv/julia_env
```
